### PR TITLE
Ability to like tracks

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,13 +85,13 @@
       {
         "command": "yandexMusic.likeTrack",
         "category": "Yandex Music",
-        "title": "Like Track",
+        "title": "Сделайте рекомендации точнее и добавьте трек в раздел \"Моя коллекция\"",
         "icon": "$(heart)"
       },
       {
         "command": "yandexMusic.dislikeTrack",
         "category": "Yandex Music",
-        "title": "Dislike Track",
+        "title": "Вам нравится этот трек, а ещё он добавлен в раздел \"Моя коллекция\"",
         "icon": {
           "light": "resources/light/heart-filled.svg",
           "dark": "resources/dark/heart-filled.svg"

--- a/package.json
+++ b/package.json
@@ -89,6 +89,15 @@
         "icon": "$(heart)"
       },
       {
+        "command": "yandexMusic.dislikeTrack",
+        "category": "Yandex Music",
+        "title": "Dislike Track",
+        "icon": {
+          "light": "resources/light/heart-filled.svg",
+          "dark": "resources/dark/heart-filled.svg"
+        }
+      },
+      {
         "command": "yandexMusic.signIn",
         "category": "Yandex Music",
         "title": "Sign In",
@@ -113,12 +122,17 @@
         {
           "command": "yandexMusic.downloadTrack",
           "group": "inline",
-          "when": "viewItem == track"
+          "when": "viewItem == track || viewItem == likedTrack"
         },
         {
           "command": "yandexMusic.likeTrack",
           "group": "inline",
           "when": "viewItem == track"
+        },
+        {
+          "command": "yandexMusic.dislikeTrack",
+          "group": "inline",
+          "when": "viewItem == likedTrack"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -134,6 +134,16 @@
           "group": "inline",
           "when": "viewItem == likedTrack"
         }
+      ],
+      "commandPalette": [
+        {
+          "command": "yandexMusic.likeTrack",
+          "when": "false"
+        },
+        {
+          "command": "yandexMusic.dislikeTrack",
+          "when": "false"
+        }
       ]
     },
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -83,6 +83,12 @@
         "icon": "$(cloud-download)"
       },
       {
+        "command": "yandexMusic.likeTrack",
+        "category": "Yandex Music",
+        "title": "Like Track",
+        "icon": "$(heart)"
+      },
+      {
         "command": "yandexMusic.signIn",
         "category": "Yandex Music",
         "title": "Sign In",
@@ -106,6 +112,11 @@
       "view/item/context": [
         {
           "command": "yandexMusic.downloadTrack",
+          "group": "inline",
+          "when": "viewItem == track"
+        },
+        {
+          "command": "yandexMusic.likeTrack",
           "group": "inline",
           "when": "viewItem == track"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,9 +73,9 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("yandexMusic.next", () => store.next()),
     vscode.commands.registerCommand("yandexMusic.prev", () => store.prev()),
     vscode.commands.registerCommand("yandexMusic.pause", () => store.pause()),
-    vscode.commands.registerCommand("yandexMusic.likeCurrentTrack", async () => {
+    vscode.commands.registerCommand("yandexMusic.toggleLikeCurrentTrack", async () => {
       if (store.currentTrack != null) {
-        await store.likeCurrentTrack();
+        await store.toggleLikeCurrentTrack();
         await refreshExplorer();
       }
     }),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,6 +79,12 @@ export async function activate(context: vscode.ExtensionContext) {
         await refreshExplorer();
       }
     }),
+    vscode.commands.registerCommand("yandexMusic.likeTrack", async (node: TrackTreeItem) => {
+      if (node.track != null) {
+        store.toggleLikeTrack(node.track);
+        await refreshExplorer();
+      }
+    }),
     vscode.commands.registerCommand("yandexMusic.rewindForward", () => store.rewind(settings.rewindTime)),
     vscode.commands.registerCommand("yandexMusic.rewindBackward", () => store.rewind(settings.rewindTime * (-1))),
     vscode.commands.registerCommand("yandexMusic.downloadTrack", (node: TrackTreeItem) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,6 +85,12 @@ export async function activate(context: vscode.ExtensionContext) {
         await refreshExplorer();
       }
     }),
+    vscode.commands.registerCommand("yandexMusic.dislikeTrack", async (node: TrackTreeItem) => {
+      if (node.track != null) {
+        store.toggleLikeTrack(node.track);
+        await refreshExplorer();
+      }
+    }),
     vscode.commands.registerCommand("yandexMusic.rewindForward", () => store.rewind(settings.rewindTime)),
     vscode.commands.registerCommand("yandexMusic.rewindBackward", () => store.rewind(settings.rewindTime * (-1))),
     vscode.commands.registerCommand("yandexMusic.downloadTrack", (node: TrackTreeItem) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,6 +73,12 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("yandexMusic.next", () => store.next()),
     vscode.commands.registerCommand("yandexMusic.prev", () => store.prev()),
     vscode.commands.registerCommand("yandexMusic.pause", () => store.pause()),
+    vscode.commands.registerCommand("yandexMusic.likeCurrentTrack", async () => {
+      if (store.currentTrack != null) {
+        await store.likeCurrentTrack();
+        await refreshExplorer();
+      }
+    }),
     vscode.commands.registerCommand("yandexMusic.rewindForward", () => store.rewind(settings.rewindTime)),
     vscode.commands.registerCommand("yandexMusic.rewindBackward", () => store.rewind(settings.rewindTime * (-1))),
     vscode.commands.registerCommand("yandexMusic.downloadTrack", (node: TrackTreeItem) => {

--- a/src/statusbar/playerBarItem.ts
+++ b/src/statusbar/playerBarItem.ts
@@ -51,15 +51,16 @@ export class PlayerBarItem {
       }
     });
 
-    autorun(() => {
-      this.currentTrack.text = getTrackShortName(store.currentTrack?.title || "");
-      this.currentTrack.tooltip = store.hasCurrentTrack ? getTrackFullName(<Track>store.currentTrack) : "";
-    });
-
     this.likeTrack = vscode.window.createStatusBarItem(alignment, priority - 0.5);
     this.likeTrack.text = "$(heart)";
     this.likeTrack.command = "yandexMusic.likeCurrentTrack";
-    this.likeTrack.tooltip = "Нравится";
+
+    autorun(() => {
+      this.currentTrack.text = getTrackShortName(store.currentTrack?.title || "");
+      this.currentTrack.tooltip = store.hasCurrentTrack ? getTrackFullName(<Track>store.currentTrack) : "";
+      this.likeTrack.tooltip = this.getLikeTooltip();
+      this.likeTrack.color = this.getLikeTrackColor();
+    });
 
     autorun(() => {
       if (this.store.hasCurrentTrack && this.store.isAuthorized()) {
@@ -72,7 +73,7 @@ export class PlayerBarItem {
     autorun(() => {
       this.nextButton.tooltip = `Следущий: ${this.store.nextTrack?.title}`;
     });
-    
+
     autorun(() => {
       if (this.store.hasNextTrack) {
         this.nextButton.show();
@@ -94,5 +95,15 @@ export class PlayerBarItem {
       this.playButton.show();
       this.pauseButton.hide();
     }
+  }
+
+  private getLikeTooltip() {
+    return this.store.currentTrack && this.store.isLikedTrack(this.store.currentTrack.id) ?
+    'Вам нравится этот трек, а ещё он добавлен в раздел "Моя коллекция"':
+    'Сделайте рекомендации точнее и добавьте трек в раздел "Моя коллекция"' ;
+  }
+
+  private getLikeTrackColor() {
+    return this.store.currentTrack && this.store.isLikedTrack(this.store.currentTrack.id) ? "red" : "gray";
   }
 }

--- a/src/statusbar/playerBarItem.ts
+++ b/src/statusbar/playerBarItem.ts
@@ -10,6 +10,7 @@ export class PlayerBarItem {
   private pauseButton: vscode.StatusBarItem;
   private nextButton: vscode.StatusBarItem;
   private currentTrack: vscode.StatusBarItem;
+  private likeTrack: vscode.StatusBarItem;
 
   constructor(private store: Store, alignment: vscode.StatusBarAlignment, priority: number) {
     this.prevButton = vscode.window.createStatusBarItem(alignment, priority);
@@ -41,10 +42,6 @@ export class PlayerBarItem {
     this.nextButton.command = "yandexMusic.next";
 
     this.currentTrack = vscode.window.createStatusBarItem(alignment, priority - 0.4);
-    autorun(() => {
-      this.currentTrack.text = getTrackShortName(store.currentTrack?.title || "");
-      this.currentTrack.tooltip = store.hasCurrentTrack ? getTrackFullName(<Track>store.currentTrack) : "";
-    });
 
     autorun(() => {
       if (this.store.hasCurrentTrack) {
@@ -55,8 +52,27 @@ export class PlayerBarItem {
     });
 
     autorun(() => {
+      this.currentTrack.text = getTrackShortName(store.currentTrack?.title || "");
+      this.currentTrack.tooltip = store.hasCurrentTrack ? getTrackFullName(<Track>store.currentTrack) : "";
+    });
+
+    this.likeTrack = vscode.window.createStatusBarItem(alignment, priority - 0.5);
+    this.likeTrack.text = "$(heart)";
+    this.likeTrack.command = "yandexMusic.likeCurrentTrack";
+    this.likeTrack.tooltip = "Нравится";
+
+    autorun(() => {
+      if (this.store.hasCurrentTrack && this.store.isAuthorized()) {
+        this.likeTrack.show();
+      } else {
+        this.likeTrack.hide();
+      }
+    });
+
+    autorun(() => {
       this.nextButton.tooltip = `Следущий: ${this.store.nextTrack?.title}`;
     });
+    
     autorun(() => {
       if (this.store.hasNextTrack) {
         this.nextButton.show();

--- a/src/statusbar/playerBarItem.ts
+++ b/src/statusbar/playerBarItem.ts
@@ -53,7 +53,7 @@ export class PlayerBarItem {
 
     this.likeTrack = vscode.window.createStatusBarItem(alignment, priority - 0.5);
     this.likeTrack.text = "$(heart)";
-    this.likeTrack.command = "yandexMusic.likeCurrentTrack";
+    this.likeTrack.command = "yandexMusic.toggleLikeCurrentTrack";
 
     autorun(() => {
       this.currentTrack.text = getTrackShortName(store.currentTrack?.title || "");
@@ -98,12 +98,12 @@ export class PlayerBarItem {
   }
 
   private getLikeTooltip() {
-    return this.store.currentTrack && this.store.isLikedTrack(this.store.currentTrack.id) ?
-    'Вам нравится этот трек, а ещё он добавлен в раздел "Моя коллекция"':
-    'Сделайте рекомендации точнее и добавьте трек в раздел "Моя коллекция"' ;
+    return this.store.isLikedCurrentTrack() ?
+      'Вам нравится этот трек, а ещё он добавлен в раздел "Моя коллекция"' :
+      'Сделайте рекомендации точнее и добавьте трек в раздел "Моя коллекция"';
   }
 
   private getLikeTrackColor() {
-    return this.store.currentTrack && this.store.isLikedTrack(this.store.currentTrack.id) ? "red" : "gray";
+    return this.store.isLikedCurrentTrack() ? "red" : "gray";
   }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -29,7 +29,7 @@ export class Store {
   private rewindPanel = new RewindBarItem(this, vscode.StatusBarAlignment.Left, 2000);
   private landingBlocks: LandingBlock[] = [];
   @observable isPlaying = false;
-  private playLists = new Map<string | number, Track[]>();
+  @observable playLists = new Map<string | number, Track[]>();
   @observable private currentTrackIndex: number | undefined;
   //TODO add "type PlayListId = string | number | undefined;"
   @observable private currentPlayListId: string | number | undefined;

--- a/src/store.ts
+++ b/src/store.ts
@@ -219,12 +219,16 @@ export class Store {
     this.isPlaying = false;
   }
 
+  async toggleLikeTrack(track: Track) {
+    await this.api.likeAction('track', createAlbumTrackId({
+      id: track.id,
+      albumId: track.albums[0].id,
+    }), this.isLikedCurrentTrack());
+  }
+
   async toggleLikeCurrentTrack() {
     if (this.currentTrack != null) {
-      await this.api.likeAction('track', createAlbumTrackId({
-        id: this.currentTrack.id,
-        albumId: this.currentTrack.albums[0].id,
-      }), this.isLikedCurrentTrack());
+      return this.toggleLikeTrack(this.currentTrack);
     }
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -91,6 +91,9 @@ export class Store {
           await this.api.getLanding(...ALL_LANDING_BLOCKS).then((resp) => {
             this.landingBlocks = resp.data.result.blocks;
           });
+
+          // Need fetch liked tracks to show like/dislike button correctly
+          await this.refreshLikedTracks();
         } catch (e) {
           vscode.window
             .showErrorMessage("Не удалось войти в Yandex аккаунт. Проверьте правильность логина и пароля.", "Изменить логин и пароль")
@@ -178,6 +181,14 @@ export class Store {
   }
 
   async getLikedTracks(): Promise<Track[]> {
+    if (this.playLists.has(LIKED_TRACKS_PLAYLIST_ID) && (this.playLists.get(LIKED_TRACKS_PLAYLIST_ID)?.length ?? 0) > 0) {
+      return Promise.resolve(this.playLists.get(LIKED_TRACKS_PLAYLIST_ID) ?? []);
+    }
+
+    return this.refreshLikedTracks();
+  }
+
+  async refreshLikedTracks() {
     const resp = await this.api.getLikedTracks();
     this.savePlaylist(LIKED_TRACKS_PLAYLIST_ID, resp.result);
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -229,6 +229,17 @@ export class Store {
     this.internalPlay((this.currentTrackIndex ?? 1) - 1);
   }
 
+  isLikedTrack(id: string) {
+    if (this.playLists.has(LIKED_TRACKS_PLAYLIST_ID)) {
+      const tracks = this.playLists.get(LIKED_TRACKS_PLAYLIST_ID) ?? [];
+      const track = tracks.find((track) => track.id === id);
+
+      return track != null;
+    }
+
+    return false;
+  }
+
   async downloadTrack(track: Track) {
     const url = await this.api.getTrackUrl(track.storageDir);
     open(url);

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,6 +13,7 @@ import { GeneratedPlayListItem } from "./yandexApi/feed/generatedPlayListItem";
 import { ElectronPlayer } from "./players/electronPlayer";
 import { YandexMusicSettings } from "./settings";
 import { ChartItem } from "./yandexApi/landing/chartitem";
+import { createAlbumTrackId } from "./yandexApi/apiUtils";
 
 export interface UserCredentials {
   username: string | undefined;
@@ -74,7 +75,7 @@ export class Store {
     return this.currentTrack != null;
   }
 
-  constructor() {}
+  constructor() { }
 
   async init(): Promise<void> {
     if (YandexMusicSettings.instance.isAuthValid()) {
@@ -205,6 +206,15 @@ export class Store {
   pause() {
     this.player.pause();
     this.isPlaying = false;
+  }
+
+  async likeCurrentTrack() {
+    if (this.currentTrack != null) {
+      await this.api.likeAction('track', createAlbumTrackId({
+        id: this.currentTrack.id,
+        albumId: this.currentTrack.albums[0].id,
+      }));
+    }
   }
 
   rewind(sec: number) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -223,7 +223,7 @@ export class Store {
     await this.api.likeAction('track', createAlbumTrackId({
       id: track.id,
       albumId: track.albums[0].id,
-    }), this.isLikedCurrentTrack());
+    }), this.isLikedTrack(track.id));
   }
 
   async toggleLikeCurrentTrack() {

--- a/src/store.ts
+++ b/src/store.ts
@@ -219,12 +219,12 @@ export class Store {
     this.isPlaying = false;
   }
 
-  async likeCurrentTrack() {
+  async toggleLikeCurrentTrack() {
     if (this.currentTrack != null) {
       await this.api.likeAction('track', createAlbumTrackId({
         id: this.currentTrack.id,
         albumId: this.currentTrack.albums[0].id,
-      }));
+      }), this.isLikedCurrentTrack());
     }
   }
 
@@ -240,7 +240,7 @@ export class Store {
     this.internalPlay((this.currentTrackIndex ?? 1) - 1);
   }
 
-  isLikedTrack(id: string) {
+  isLikedTrack(id: string): boolean {
     if (this.playLists.has(LIKED_TRACKS_PLAYLIST_ID)) {
       const tracks = this.playLists.get(LIKED_TRACKS_PLAYLIST_ID) ?? [];
       const track = tracks.find((track) => track.id === id);
@@ -249,6 +249,10 @@ export class Store {
     }
 
     return false;
+  }
+
+  isLikedCurrentTrack(): boolean {
+    return this.currentTrack != null && this.isLikedTrack(this.currentTrack.id);
   }
 
   async downloadTrack(track: Track) {

--- a/src/tree/chartTree.ts
+++ b/src/tree/chartTree.ts
@@ -19,7 +19,7 @@ export class ChartTree implements vscode.TreeDataProvider<vscode.TreeItem> {
 
     getChildren(): vscode.ProviderResult<vscode.TreeItem[]> {
         return this.store.getChart().then((items) => {
-            return items.map((item) => new ChartTreeItem(item, CHART_TRACKS_PLAYLIST_ID));
+            return items.map((item) => new ChartTreeItem(this.store, item, CHART_TRACKS_PLAYLIST_ID));
         });
     }
 }

--- a/src/tree/childrenLoader.ts
+++ b/src/tree/childrenLoader.ts
@@ -13,7 +13,7 @@ export function getChildren(store: Store, element?: vscode.TreeItem): vscode.Pro
 
     if (element instanceof PlayListTreeItem) {
         return store.getTracks(element.playList.owner.uid, element.playList.kind).then((resp) => {
-            return resp.data.result.tracks.map((item) => new TrackTreeItem(<Track>item.track, element.playList.kind));
+            return resp.data.result.tracks.map((item) => new TrackTreeItem(store, <Track>item.track, element.playList.kind));
         });
     }
 
@@ -25,13 +25,13 @@ export function getChildren(store: Store, element?: vscode.TreeItem): vscode.Pro
 
     if (element instanceof AlbumTreeItem) {
         return store.getAlbumTracks(element.album.id).then((tracks) => {
-            return tracks.map((item) => new TrackTreeItem(item, element.album.id));
+            return tracks.map((item) => new TrackTreeItem(store, item, element.album.id));
         });
     }
 
     if (element instanceof LikedTracksTreeItem) {
         return store.getLikedTracks().then((tracks) => {
-            return tracks.map((item) => new TrackTreeItem(<Track>item, LIKED_TRACKS_PLAYLIST_ID));
+            return tracks.map((item) => new TrackTreeItem(store, <Track>item, LIKED_TRACKS_PLAYLIST_ID));
         });
     }
 

--- a/src/tree/treeItems/chartTreeItem.ts
+++ b/src/tree/treeItems/chartTreeItem.ts
@@ -4,11 +4,12 @@ import { getArtists } from "../../yandexApi/apiUtils";
 import { getThemeIcon } from "../../utils/iconUtils";
 import { ChartItem } from "../../yandexApi/landing/chartitem";
 import { TrackTreeItem } from "../treeItems/trackTreeItem";
+import { Store } from "../../store";
 
 export class ChartTreeItem extends TrackTreeItem {
-  constructor(item: ChartItem, public readonly playListId: string | number) {
-    super(item.track, vscode.TreeItemCollapsibleState.None);
-    
+  constructor(store: Store, item: ChartItem, public readonly playListId: string | number) {
+    super(store, item.track, vscode.TreeItemCollapsibleState.None);
+
     this.label = `${item.chart.position}. ${item.track.title} - ${getArtists(item.track)}`;
     this.command = {
       command: "yandexMusic.play",

--- a/src/tree/treeItems/chartTreeItem.ts
+++ b/src/tree/treeItems/chartTreeItem.ts
@@ -1,7 +1,5 @@
 import * as vscode from "vscode";
-import { Track } from "../../yandexApi/interfaces";
 import { getArtists } from "../../yandexApi/apiUtils";
-import { getThemeIcon } from "../../utils/iconUtils";
 import { ChartItem } from "../../yandexApi/landing/chartitem";
 import { TrackTreeItem } from "../treeItems/trackTreeItem";
 import { Store } from "../../store";
@@ -11,14 +9,5 @@ export class ChartTreeItem extends TrackTreeItem {
     super(store, item.track, vscode.TreeItemCollapsibleState.None);
 
     this.label = `${item.chart.position}. ${item.track.title} - ${getArtists(item.track)}`;
-    this.command = {
-      command: "yandexMusic.play",
-      title: "Play Track",
-      tooltip: `Play ${this.label}`,
-      arguments: [this],
-    };
-
-    this.iconPath = getThemeIcon("track.svg");
-    this.contextValue = "track";
   }
 }

--- a/src/tree/treeItems/trackTreeItem.ts
+++ b/src/tree/treeItems/trackTreeItem.ts
@@ -2,9 +2,10 @@ import * as vscode from "vscode";
 import { Track } from "../../yandexApi/interfaces";
 import { getArtists } from "../../yandexApi/apiUtils";
 import { getThemeIcon } from "../../utils/iconUtils";
+import { Store } from "../../store";
 
 export class TrackTreeItem extends vscode.TreeItem {
-  constructor(public readonly track: Track, public readonly playListId: string | number) {
+  constructor(private store: Store, public readonly track: Track, public readonly playListId: string | number) {
     super(`${track.title} - ${getArtists(track)}`, vscode.TreeItemCollapsibleState.None);
     this.command = {
       command: "yandexMusic.play",
@@ -14,6 +15,6 @@ export class TrackTreeItem extends vscode.TreeItem {
     };
 
     this.iconPath = getThemeIcon("track.svg");
-    this.contextValue = "track";
+    this.contextValue = store.isLikedTrack(this.track.id) ? "likedTrack" : "track";
   }
 }

--- a/src/yandexApi/album/album.ts
+++ b/src/yandexApi/album/album.ts
@@ -6,7 +6,7 @@ export interface Album {
     /**
      * Getting albom error
      */
-    error: string;
+    error?: string;
     title: string;
     type: "single" | "podcast" | string;
     metaType: "single" | "podcast" | "music" | string;

--- a/src/yandexApi/apiUtils.ts
+++ b/src/yandexApi/apiUtils.ts
@@ -1,8 +1,15 @@
 import { Track } from "./interfaces";
 import { NewPlayListItem } from "./responces/fullNewPlayLists";
 
-export function createTrackAlbumIds(tracks: { id: string; albumId: string }[]): string[] {
-  return tracks.map((track) => `${track.id}:${track.albumId}`);
+export function createTrackAlbumIds(tracks: { id: string | number, albumId: string | number }[]): string[] {
+  return tracks.map((track) => createAlbumTrackId(track));
+}
+
+/**
+ * Every track can be many albums so to perform operation with track from certain album need to use combination of track id and album id
+ */
+export function createAlbumTrackId(track: { id: string | number, albumId: string | number }): string {
+  return `${track.id}:${track.albumId}`;
 }
 
 export function getPlayListsIds(playLists: NewPlayListItem[]) {

--- a/src/yandexApi/interfaces.ts
+++ b/src/yandexApi/interfaces.ts
@@ -1,5 +1,6 @@
 import { LandingBlock } from "./landing/block";
 import { GeneratedPlayListItem } from "./feed/generatedPlayListItem";
+import { Album } from "./album/album";
 
 export interface GetPlayListsOptions {
   mixed?: boolean;
@@ -55,7 +56,7 @@ export interface Artist {
 }
 
 export interface Track {
-  albums: any[];
+  albums: Album[];
   artists: Artist[];
   available: boolean;
   availableForPremiumUsers: boolean;

--- a/src/yandexApi/yandexMusicApi.ts
+++ b/src/yandexApi/yandexMusicApi.ts
@@ -98,10 +98,17 @@ export class YandexMusicApi {
     },
   };
 
-  constructor() {}
+  constructor() { }
 
   private _getAuthHeader() {
     return { Authorization: "OAuth " + this._config.user.TOKEN };
+  }
+
+  private getHeaders(additionalHeaders: { [key: string]: any }): { [key: string]: any } {
+    return {
+      ...this._getAuthHeader(),
+      ...additionalHeaders,
+    };
   }
 
   init(config: InitConfig): Promise<InitResponse> {
@@ -458,6 +465,22 @@ export class YandexMusicApi {
         headers: this._getAuthHeader(),
       }
     );
+  }
+
+  async likeAction(objectType: 'track' | 'artist' | 'playlist' | 'album', ids: number | string | number[] | string[], remove = false): Promise<any> {
+    const action = remove ? 'remove' : 'add-multiple';
+    const result = await this.apiClient.post<GetTracksResponse>(`/users/${this._config.user.UID}/likes/${objectType}s/${action}`,
+      querystring.stringify({
+        [`${objectType}-ids`]: Array.isArray(ids) ? ids.join(",") : ids,
+      }),
+      {
+        headers: this.getHeaders({
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
+      }
+    );
+
+    return result;
   }
 
   async getLikedTracksIds(): Promise<LikedTracksResponse> {


### PR DESCRIPTION
- [x]  ability to like track in a statusbar
- [x]  ability to dislike track in a statusbar
- [x]  ability to like track in a tree
- [x]  ability to dislike track in a tree
- [x] use the same title for sidebar like button and tree like button ()
- [x]  show filled red heart icon when song is liked
- [x] show like/dislike buttons only for authorized user

![image](https://user-images.githubusercontent.com/9947582/90558096-2e8b7900-e1a4-11ea-94d7-bd5b11409029.png)

This sample project contains good internationalization example [https://github.com/microsoft/vscode-extension-samples/tree/8d43af086869d6fd4353d4c65548732da5cd095f/i18n-sample](i18n-sample). In this way, we can use the same title for inline actions (in tree view) and for actions in status bar. But it is will be done in separated MR.

Fixes #4 