### PR TITLE
Search songs, podcasts, albums

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "version": "0.9.0",
   "preview": true,
   "engines": {
-    "vscode": "^1.41.0"
+    "vscode": "^1.53.0"
   },
   "categories": [
     "Other"
@@ -238,7 +238,7 @@
     "@types/glob": "^7.1.1",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.11.7",
-    "@types/vscode": "^1.41.0",
+    "@types/vscode": "^1.53.0",
     "glob": "^7.1.5",
     "mocha": "^6.2.2",
     "tslint": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "viewsWelcome": [
       {
         "view": "yandex-music-search",
-        "contents": "Поиск по трекам, альбомам, исполнителчям и подкастам. \n[Поиск](command:yandexMusic.search)"
+        "contents": "Поиск по трекам, альбомам, исполнителям и подкастам. \n[Поиск](command:yandexMusic.search)"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "activationEvents": [
     "onView:yandex-music-play-lists",
     "onView:yandex-music-chart",
-    "onView:yandex-music-recommendations"
+    "onView:yandex-music-recommendations",
+    "onView:yandex-music-search"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
       {
         "command": "yandexMusic.search",
         "category": "Yandex Music",
-        "title": "Search"
+        "title": "Search",
+        "icon": "$(search)"
       }
     ],
     "menus": {
@@ -119,6 +120,11 @@
           "command": "yandexMusic.refresh",
           "group": "navigation",
           "when": "view == yandex-music-play-lists || view == yandex-music-chart || view == yandex-music-recommendations"
+        },
+        {
+          "command": "yandexMusic.search",
+          "group": "navigation",
+          "when": "view == yandex-music-search"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
         {
           "command": "yandexMusic.clearSearchResult",
           "group": "navigation",
-          "when": "view == yandex-music-search"
+          "when": "view == yandex-music-search && yandexMusic.hasSearchResult"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
     "Other"
   ],
   "activationEvents": [
-    "onView:yandex-music-play-lists",
-    "onView:yandex-music-chart",
-    "onView:yandex-music-recommendations",
-    "onView:yandex-music-search"
+    "onStartupFinished"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,12 @@
         "category": "Yandex Music",
         "title": "Search",
         "icon": "$(search)"
+      },
+      {
+        "command": "yandexMusic.clearSearchResult",
+        "category": "Yandex Music",
+        "title": "Clear Search Result",
+        "icon": "$(clear-all)"
       }
     ],
     "menus": {
@@ -123,6 +129,11 @@
         },
         {
           "command": "yandexMusic.search",
+          "group": "navigation",
+          "when": "view == yandex-music-search"
+        },
+        {
+          "command": "yandexMusic.clearSearchResult",
           "group": "navigation",
           "when": "view == yandex-music-search"
         }

--- a/package.json
+++ b/package.json
@@ -219,7 +219,13 @@
           "name": "Search"
         }
       ]
-    }
+    },
+    "viewsWelcome": [
+      {
+        "view": "yandex-music-search",
+        "contents": "Поиск по трекам, альбомам, исполнителчям и подкастам. \n[Поиск](command:yandexMusic.search)"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,11 @@
         "category": "Yandex Music",
         "title": "Refresh play lists",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "yandexMusic.search",
+        "category": "Yandex Music",
+        "title": "Search"
       }
     ],
     "menus": {
@@ -204,6 +209,10 @@
         {
           "id": "yandex-music-recommendations",
           "name": "Recommendations"
+        },
+        {
+          "id": "yandex-music-search",
+          "name": "Search"
         }
       ]
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,7 +105,7 @@ export async function activate(context: vscode.ExtensionContext) {
       const searchText = await showSearchBox();
 
       if (searchText) {
-        store.searchText = searchText;
+        store.doSearch(searchText);
       }
     }),
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,6 +108,10 @@ export async function activate(context: vscode.ExtensionContext) {
         store.doSearch(searchText);
       }
     }),
+    vscode.commands.registerCommand("yandexMusic.clearSearchResult", async () => {
+      //TODO need to show clear results icon only when there are results 
+      store.clearSearchResult();
+    })
   );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("yandexMusic.refresh", refreshExplorer),
     vscode.commands.registerCommand("yandexMusic.play", async (item?: TrackTreeItem) => {
       if (item) {
-        store.play({ itemId: item.track.id, playListId: item.playListId });
+        store.play({ itemId: item.track.id, playListId: item.playListId.toString() });
       } else {
         store.play();
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -109,7 +109,6 @@ export async function activate(context: vscode.ExtensionContext) {
       }
     }),
     vscode.commands.registerCommand("yandexMusic.clearSearchResult", async () => {
-      //TODO need to show clear results icon only when there are results 
       store.clearSearchResult();
     })
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,9 +2,10 @@ import * as vscode from "vscode";
 import { PlayListTree } from "./tree/playListTree";
 import { TrackTreeItem } from "./tree/treeItems";
 import { Store } from "./store";
-import { signIn } from "./inputs";
+import { showSearchBox, signIn } from "./inputs";
 import { ChartTree } from "./tree/chartTree";
 import { RecommendationTree } from "./tree/recommendationTree";
+import { SearchTree } from './tree/searchTree';
 import { YandexMusicSettings } from "./settings";
 import { isOnline } from "./utils/connectionUtils";
 
@@ -13,6 +14,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const treeProvider = new PlayListTree(store);
   const chartProvider = new ChartTree(store);
   const recommendationProvider = new RecommendationTree(store);
+  const searchProvider = new SearchTree(store);
 
   YandexMusicSettings.init(context.globalState);
   const settings = YandexMusicSettings.instance;
@@ -27,8 +29,10 @@ export async function activate(context: vscode.ExtensionContext) {
     if (store.isAuthorized()) {
       playListTreeView.message = `Вы вошли как: ${settings.username}`;
     }
-    const chartTreeView = vscode.window.createTreeView("yandex-music-chart", { treeDataProvider: chartProvider });
-    const recommendationsTreeView = vscode.window.createTreeView("yandex-music-recommendations", { treeDataProvider: recommendationProvider });
+
+    vscode.window.createTreeView("yandex-music-chart", { treeDataProvider: chartProvider });
+    vscode.window.createTreeView("yandex-music-recommendations", { treeDataProvider: recommendationProvider });
+    vscode.window.createTreeView("yandex-music-search", { treeDataProvider: searchProvider });
 
     settings.onDidChangeSettings((e) => {
       if (e.affectsConfiguration("yandexMusic.credentials")) {
@@ -97,6 +101,13 @@ export async function activate(context: vscode.ExtensionContext) {
       store.downloadTrack(node.track);
     }),
     vscode.commands.registerCommand("yandexMusic.signIn", signIn),
+    vscode.commands.registerCommand("yandexMusic.search", async () => {
+      const searchText = await showSearchBox();
+
+      if (searchText) {
+        store.searchText = searchText;
+      }
+    }),
   );
 }
 

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -40,3 +40,16 @@ export async function showPasswordBox(value?: string): Promise<string | undefine
 
   return name;
 }
+
+export async function showSearchBox() {
+  // TODO: show search history like on music.yandex.ru
+  const name = await vscode.window.showInputBox({
+    prompt: "Поиск",
+    placeHolder: "Трек, альбом, исполнитель, подкаст",
+    validateInput: text => {
+      return !text ? "Значение должно быть не пустым!" : null;
+    }
+  });
+
+  return name;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -106,13 +106,15 @@ export class Store {
             .then(() => {
               vscode.commands.executeCommand("yandexMusic.signIn");
             });
+          console.error(e);
         }
 
         autorun(() => {
           vscode.commands.executeCommand("setContext", "yandexMusic.isPlaying", this.isPlaying);
         });
       } catch (ex) {
-        vscode.window.showErrorMessage(`Unknown exception: ${JSON.stringify(ex)}`);
+        vscode.window.showErrorMessage(`Неизвестная ошибка: ${JSON.stringify(ex)}`);
+        console.error(ex);
       }
     }
 
@@ -122,22 +124,27 @@ export class Store {
 
     this.player.on("error", (error) => {
       vscode.window.showErrorMessage(JSON.stringify(error));
+      console.error(error);
     });
 
     return await Promise.resolve();
   }
 
-  async doSearch(searchText: string): Promise<SearchResult> {
-    //TODO add error handling
-    this.searchText = searchText;
-    this.searchResult = (await this.api.search(this.searchText)).data.result;
-    vscode.commands.executeCommand("setContext", "yandexMusic.hasSearchResult", true);
-    if (this.searchResult.tracks) {
-      this.savePlaylist(SEARCH_TRACKS_PLAYLIST_ID, this.searchResult.tracks.results);
-    } else {
-      this.removePlaylist(SEARCH_TRACKS_PLAYLIST_ID);
+  async doSearch(searchText: string) {
+    try {
+      this.searchText = searchText;
+      this.searchResult = (await this.api.search(this.searchText)).data.result;
+      vscode.commands.executeCommand("setContext", "yandexMusic.hasSearchResult", true);
+      if (this.searchResult.tracks) {
+        this.savePlaylist(SEARCH_TRACKS_PLAYLIST_ID, this.searchResult.tracks.results);
+      } else {
+        this.removePlaylist(SEARCH_TRACKS_PLAYLIST_ID);
+      }
+    } catch (e) {
+      vscode.window
+        .showErrorMessage("Не удалось выполнить поиск.");
+      console.error(e);
     }
-    return this.searchResult;
   }
 
   clearSearchResult() {
@@ -270,6 +277,7 @@ export class Store {
           });
       } else {
         vscode.window.showErrorMessage("Неизвестная ошибка ошибка");
+        console.error(ex);
       }
     }
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -38,6 +38,8 @@ export class Store {
   private searchText = '';
   @observable searchResponse: SearchResult | undefined;
 
+  // TODO create abstraction around "YandexMusicApi" which will be called "PlayListLoader" or "PlayListProvider" 
+  // where we will be able to hide all logic about adding custom identifiers like we have in searchTree
   api = new YandexMusicApi();
 
   isAuthorized(): boolean {

--- a/src/store.ts
+++ b/src/store.ts
@@ -30,6 +30,7 @@ export class Store {
   private landingBlocks: LandingBlock[] = [];
   @observable searchText = '';
   @observable isPlaying = false;
+  // TODO: implement PlayList class which will implement "loadMore" function
   @observable playLists = new Map<string | number, Track[]>();
   @observable private currentTrackIndex: number | undefined;
   //TODO add "type PlayListId = string | number | undefined;"
@@ -206,7 +207,7 @@ export class Store {
           this.internalPlay(index);
         }
       } else {
-        console.error(`playlist ${track?.itemId}`);
+        console.error(`playlist ${track?.itemId} is not found`);
       }
       // update current song
     } else {

--- a/src/store.ts
+++ b/src/store.ts
@@ -36,7 +36,7 @@ export class Store {
   //TODO add "type PlayListId = string | number | undefined;"
   @observable private currentPlayListId: string | undefined;
   private searchText = '';
-  @observable searchResponse: SearchResult | undefined;
+  @observable searchResult: SearchResult | undefined;
 
   // TODO create abstraction around "YandexMusicApi" which will be called "PlayListLoader" or "PlayListProvider" 
   // where we will be able to hide all logic about adding custom identifiers like we have in searchTree
@@ -130,18 +130,18 @@ export class Store {
   async doSearch(searchText: string): Promise<SearchResult> {
     //TODO add error handling
     this.searchText = searchText;
-    this.searchResponse = (await this.api.search(this.searchText)).data.result;
+    this.searchResult = (await this.api.search(this.searchText)).data.result;
     vscode.commands.executeCommand("setContext", "yandexMusic.hasSearchResult", true);
-    if (this.searchResponse.tracks) {
-      this.savePlaylist(SEARCH_TRACKS_PLAYLIST_ID, this.searchResponse.tracks.results);
+    if (this.searchResult.tracks) {
+      this.savePlaylist(SEARCH_TRACKS_PLAYLIST_ID, this.searchResult.tracks.results);
     } else {
       this.removePlaylist(SEARCH_TRACKS_PLAYLIST_ID);
     }
-    return this.searchResponse;
+    return this.searchResult;
   }
 
   clearSearchResult() {
-    this.searchResponse = undefined;
+    this.searchResult = undefined;
     vscode.commands.executeCommand("setContext", "yandexMusic.hasSearchResult", false);
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -28,6 +28,7 @@ export class Store {
   private playerControlPanel = new PlayerBarItem(this, vscode.StatusBarAlignment.Left, 2001);
   private rewindPanel = new RewindBarItem(this, vscode.StatusBarAlignment.Left, 2000);
   private landingBlocks: LandingBlock[] = [];
+  @observable searchText = '';
   @observable isPlaying = false;
   @observable playLists = new Map<string | number, Track[]>();
   @observable private currentTrackIndex: number | undefined;

--- a/src/store.ts
+++ b/src/store.ts
@@ -131,6 +131,7 @@ export class Store {
     //TODO add error handling
     this.searchText = searchText;
     this.searchResponse = (await this.api.search(this.searchText)).data.result;
+    vscode.commands.executeCommand("setContext", "yandexMusic.hasSearchResult", true);
     if (this.searchResponse.tracks) {
       this.savePlaylist(SEARCH_TRACKS_PLAYLIST_ID, this.searchResponse.tracks.results);
     } else {
@@ -141,6 +142,7 @@ export class Store {
 
   clearSearchResult() {
     this.searchResponse = undefined;
+    vscode.commands.executeCommand("setContext", "yandexMusic.hasSearchResult", false);
   }
 
   getLandingBlock(type: string) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -139,6 +139,10 @@ export class Store {
     return this.searchResponse;
   }
 
+  clearSearchResult() {
+    this.searchResponse = undefined;
+  }
+
   getLandingBlock(type: string) {
     return this.landingBlocks.find((item) => item.type === type);
   }

--- a/src/tree/childrenLoader.ts
+++ b/src/tree/childrenLoader.ts
@@ -42,8 +42,10 @@ export function getChildren(store: Store, element?: vscode.TreeItem): vscode.Pro
         });
     }
 
-    if(element instanceof ArtistTreeItem) {
-        return element.getChildren();
+    if (element instanceof ArtistTreeItem) {
+        return store.getArtistTracks(element.artist.id.toString()).then(tracks => {
+            return tracks.map((track) => new TrackTreeItem(store, track, element.artist.id));
+        });
     }
 
     return null;

--- a/src/tree/childrenLoader.ts
+++ b/src/tree/childrenLoader.ts
@@ -3,6 +3,7 @@ import { NewPlayListsTreeItem, PlayListTreeItem, TrackTreeItem, NewReleasesTreeI
 import { Store, LIKED_TRACKS_PLAYLIST_ID } from '../store';
 import { Track } from '../yandexApi/interfaces';
 import { ActualPodcastsTreeItem } from './treeItems/actualPodcastsTreeItem';
+import { ArtistTreeItem } from './treeItems/artistTreeItem';
 
 export function getChildren(store: Store, element?: vscode.TreeItem): vscode.ProviderResult<vscode.TreeItem[]> {
     if (element instanceof NewPlayListsTreeItem) {
@@ -39,6 +40,10 @@ export function getChildren(store: Store, element?: vscode.TreeItem): vscode.Pro
         return store.getActualPodcasts().then((albums) => {
             return albums.map((item) => new AlbumTreeItem(item));
         });
+    }
+
+    if(element instanceof ArtistTreeItem) {
+        return element.getChildren();
     }
 
     return null;

--- a/src/tree/searchTree.ts
+++ b/src/tree/searchTree.ts
@@ -34,55 +34,28 @@ export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
         if (!element) {
             const searchItems: vscode.TreeItem[] = [];
 
-            if (responce.tracks) {
-                const tracksItem = new vscode.TreeItem('Треки', vscode.TreeItemCollapsibleState.Expanded);
-                tracksItem.id = 'search-tracks-item';
-                tracksItem.iconPath = getThemeIcon("track.svg");
-                searchItems.push(tracksItem);
-            }
-
-            if (responce.albums) {
-                const albumsItem = new vscode.TreeItem('Альбомы', vscode.TreeItemCollapsibleState.Expanded);
-                albumsItem.id = 'search-albums-item';
-                albumsItem.iconPath = getThemeIcon("playlist.svg");
-                searchItems.push(albumsItem);
-            }
-
-            if (responce.playlists) {
-                const playListsItem = new vscode.TreeItem('Плейлисты', vscode.TreeItemCollapsibleState.Expanded);
-                playListsItem.id = 'search-playlists-item';
-                playListsItem.iconPath = getThemeIcon("playlist.svg");
-                searchItems.push(playListsItem);
-            }
-
-            if (responce.artists) {
-                const artistsItem = new vscode.TreeItem('Исполнители', vscode.TreeItemCollapsibleState.Expanded);
-                artistsItem.iconPath = new vscode.ThemeIcon("organization");
-                artistsItem.id = 'search-artists-item';
-                searchItems.push(artistsItem);
-            }
+            responce.tracks && searchItems.push(createTracksItem());
+            responce.albums && searchItems.push(createAlbumsItem());
+            responce.playlists && searchItems.push(createPlayListsItem());
+            responce.artists && searchItems.push(createArtistsItem());
 
             return searchItems;
         }
 
-        if (element.id === 'search-tracks-item') {
-            const items = responce.tracks.results.map(item => new TrackTreeItem(this.store, item, SEARCH_TRACKS_PLAYLIST_ID));
-            return items;
+        if (element.id === tracksItemId) {
+            return responce.tracks.results.map(item => new TrackTreeItem(this.store, item, SEARCH_TRACKS_PLAYLIST_ID));
         }
 
-        if (element.id === 'search-albums-item') {
-            const items = responce.albums.results.map(item => new AlbumTreeItem(item));
-            return items;
+        if (element.id === albumsItemId) {
+            return responce.albums.results.map(item => new AlbumTreeItem(item));
         }
 
-        if (element.id === 'search-playlists-item') {
-            const items = responce.playlists.results.map(item => new PlayListTreeItem(item));
-            return items;
+        if (element.id === playListsItemId) {
+            return responce.playlists.results.map(item => new PlayListTreeItem(item));
         }
 
-        if (element.id === 'search-artists-item') {
-            const items = responce.artists.results.map(item => new ArtistTreeItem(this.store, item));
-            return items;
+        if (element.id === artistsItemId) {
+            return responce.artists.results.map(item => new ArtistTreeItem(this.store, item));
         }
 
         if (element instanceof AlbumTreeItem || element instanceof PlayListTreeItem || element instanceof ArtistTreeItem) {
@@ -91,4 +64,37 @@ export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
 
         return [];
     }
+}
+
+const tracksItemId = 'search-tracks-item';
+const albumsItemId = 'search-albums-item';
+const playListsItemId = 'search-playlists-item';
+const artistsItemId = 'search-artists-item'; 
+
+function createTracksItem() {
+    const tracksItem = new vscode.TreeItem('Треки', vscode.TreeItemCollapsibleState.Expanded);
+    tracksItem.id = tracksItemId;
+    tracksItem.iconPath = getThemeIcon("track.svg");
+    return tracksItem;
+}
+
+function createAlbumsItem() {
+    const albumsItem = new vscode.TreeItem('Альбомы', vscode.TreeItemCollapsibleState.Expanded);
+    albumsItem.id = albumsItemId;
+    albumsItem.iconPath = getThemeIcon("playlist.svg");
+    return albumsItem;
+}
+
+function createPlayListsItem() {
+    const playListsItem = new vscode.TreeItem('Плейлисты', vscode.TreeItemCollapsibleState.Expanded);
+    playListsItem.id = playListsItemId;
+    playListsItem.iconPath = getThemeIcon("playlist.svg");
+    return playListsItem;
+}
+
+function createArtistsItem() {
+    const artistsItem = new vscode.TreeItem('Исполнители', vscode.TreeItemCollapsibleState.Expanded);
+    artistsItem.id = artistsItemId;
+    artistsItem.iconPath = new vscode.ThemeIcon("organization");
+    return artistsItem;
 }

--- a/src/tree/searchTree.ts
+++ b/src/tree/searchTree.ts
@@ -1,6 +1,7 @@
-import { autorun, observable, observe } from 'mobx';
+import { observe } from 'mobx';
 import * as vscode from 'vscode';
 import { SEARCH_TRACKS_PLAYLIST_ID, Store } from '../store';
+import { getThemeIcon } from '../utils/iconUtils';
 import { getChildren } from './childrenLoader';
 import { AlbumTreeItem, PlayListTreeItem, TrackTreeItem } from './treeItems';
 import { ArtistTreeItem } from './treeItems/artistTreeItem';
@@ -36,23 +37,27 @@ export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
             if (responce.tracks) {
                 const tracksItem = new vscode.TreeItem('Треки', vscode.TreeItemCollapsibleState.Expanded);
                 tracksItem.id = 'search-tracks-item';
+                tracksItem.iconPath = getThemeIcon("track.svg");
                 searchItems.push(tracksItem);
             }
 
             if (responce.albums) {
                 const albumsItem = new vscode.TreeItem('Альбомы', vscode.TreeItemCollapsibleState.Expanded);
                 albumsItem.id = 'search-albums-item';
+                albumsItem.iconPath = getThemeIcon("playlist.svg");
                 searchItems.push(albumsItem);
             }
 
             if (responce.playlists) {
                 const playListsItem = new vscode.TreeItem('Плейлисты', vscode.TreeItemCollapsibleState.Expanded);
                 playListsItem.id = 'search-playlists-item';
+                playListsItem.iconPath = getThemeIcon("playlist.svg");
                 searchItems.push(playListsItem);
             }
 
             if (responce.artists) {
                 const artistsItem = new vscode.TreeItem('Исполнители', vscode.TreeItemCollapsibleState.Expanded);
+                artistsItem.iconPath = new vscode.ThemeIcon("organization");
                 artistsItem.id = 'search-artists-item';
                 searchItems.push(artistsItem);
             }

--- a/src/tree/searchTree.ts
+++ b/src/tree/searchTree.ts
@@ -10,7 +10,7 @@ export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
     constructor(private store: Store) {
-        observe(store, "searchResponce", () => {
+        observe(store, "searchResponse", () => {
             this.refresh();
         });
     }
@@ -24,11 +24,11 @@ export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
     }
 
     async getChildren(element?: vscode.TreeItem) {
-        if (!this.store.searchResponce) {
+        if (!this.store.searchResponse) {
             return;
         }
 
-        const responce = this.store.searchResponce;
+        const responce = this.store.searchResponse;
 
         if (!element) {
             const searchItems: vscode.TreeItem[] = [];

--- a/src/tree/searchTree.ts
+++ b/src/tree/searchTree.ts
@@ -1,12 +1,14 @@
 import { autorun, observable, observe } from 'mobx';
 import * as vscode from 'vscode';
 import { Store } from '../store';
+import { getChildren } from './childrenLoader';
+import { AlbumTreeItem, PlayListTreeItem, TrackTreeItem } from './treeItems';
 
 export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
     private _onDidChangeTreeData = new vscode.EventEmitter<vscode.TreeItem | undefined>();
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
-    constructor(private store: Store) { 
+    constructor(private store: Store) {
         observe(store, "searchText", () => {
             this.refresh();
         });
@@ -20,8 +22,53 @@ export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
         return element;
     }
 
-    getChildren(element?: vscode.TreeItem): vscode.ProviderResult<vscode.TreeItem[]> {
-        return [new vscode.TreeItem(this.store.searchText)];
-        // return [];
+    async getChildren(element?: vscode.TreeItem) {
+        if (!this.store.searchText) {
+            return;
+        }
+
+        if (!element) {
+            const tracksItem = new vscode.TreeItem('Треки', vscode.TreeItemCollapsibleState.Expanded);
+            tracksItem.id = 'search-tracks-item';
+
+            const albumsItem = new vscode.TreeItem('Альбомы', vscode.TreeItemCollapsibleState.Expanded);
+            albumsItem.id = 'search-albums-item';
+
+            const playListsItem = new vscode.TreeItem('Плейлисты', vscode.TreeItemCollapsibleState.Expanded);
+            playListsItem.id = 'search-playlists-item';
+
+            return [
+                tracksItem,
+                albumsItem,
+                playListsItem,
+            ];
+        }
+
+        if (element.id === 'search-tracks-item') {
+            // TODO: no need to make request, need to refactor
+            const responce = await this.store.api.search(this.store.searchText);
+            const items = responce.data.result.tracks.results.map(item => new TrackTreeItem(this.store, item, ''));
+            return items;
+        }
+
+        if (element.id === 'search-albums-item') {
+            // TODO: no need to make request, need to refactor
+            const responce = await this.store.api.search(this.store.searchText);
+            const items = responce.data.result.albums.results.map(item => new AlbumTreeItem(item));
+            return items;
+        }
+
+        if (element.id === 'search-playlists-item') {
+            // TODO: no need to make request, need to refactor
+            const responce = await this.store.api.search(this.store.searchText);
+            const items = responce.data.result.playlists.results.map(item => new PlayListTreeItem(item));
+            return items;
+        }
+
+        if (element instanceof AlbumTreeItem || element instanceof PlayListTreeItem) {
+            return getChildren(this.store, element);
+        }
+
+        return [];
     }
 }

--- a/src/tree/searchTree.ts
+++ b/src/tree/searchTree.ts
@@ -1,0 +1,27 @@
+import { autorun, observable, observe } from 'mobx';
+import * as vscode from 'vscode';
+import { Store } from '../store';
+
+export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
+    private _onDidChangeTreeData = new vscode.EventEmitter<vscode.TreeItem | undefined>();
+    readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+    constructor(private store: Store) { 
+        observe(store, "searchText", () => {
+            this.refresh();
+        });
+    }
+
+    refresh(item?: vscode.TreeItem): void {
+        this._onDidChangeTreeData.fire(item);
+    }
+
+    getTreeItem(element: vscode.TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
+        return element;
+    }
+
+    getChildren(element?: vscode.TreeItem): vscode.ProviderResult<vscode.TreeItem[]> {
+        return [new vscode.TreeItem(this.store.searchText)];
+        // return [];
+    }
+}

--- a/src/tree/searchTree.ts
+++ b/src/tree/searchTree.ts
@@ -1,6 +1,6 @@
 import { autorun, observable, observe } from 'mobx';
 import * as vscode from 'vscode';
-import { Store } from '../store';
+import { SEARCH_TRACKS_PLAYLIST_ID, Store } from '../store';
 import { getChildren } from './childrenLoader';
 import { AlbumTreeItem, PlayListTreeItem, TrackTreeItem } from './treeItems';
 import { ArtistTreeItem } from './treeItems/artistTreeItem';
@@ -10,7 +10,7 @@ export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
     constructor(private store: Store) {
-        observe(store, "searchText", () => {
+        observe(store, "searchResponce", () => {
             this.refresh();
         });
     }
@@ -24,56 +24,59 @@ export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
     }
 
     async getChildren(element?: vscode.TreeItem) {
-        if (!this.store.searchText) {
+        if (!this.store.searchResponce) {
             return;
         }
 
+        const responce = this.store.searchResponce;
+
         if (!element) {
-            const tracksItem = new vscode.TreeItem('Треки', vscode.TreeItemCollapsibleState.Expanded);
-            tracksItem.id = 'search-tracks-item';
+            const searchItems: vscode.TreeItem[] = [];
 
-            const albumsItem = new vscode.TreeItem('Альбомы', vscode.TreeItemCollapsibleState.Expanded);
-            albumsItem.id = 'search-albums-item';
+            if (responce.tracks) {
+                const tracksItem = new vscode.TreeItem('Треки', vscode.TreeItemCollapsibleState.Expanded);
+                tracksItem.id = 'search-tracks-item';
+                searchItems.push(tracksItem);
+            }
 
-            const playListsItem = new vscode.TreeItem('Плейлисты', vscode.TreeItemCollapsibleState.Expanded);
-            playListsItem.id = 'search-playlists-item';
+            if (responce.albums) {
+                const albumsItem = new vscode.TreeItem('Альбомы', vscode.TreeItemCollapsibleState.Expanded);
+                albumsItem.id = 'search-albums-item';
+                searchItems.push(albumsItem);
+            }
 
-            const artistsItem = new vscode.TreeItem('Исполнители', vscode.TreeItemCollapsibleState.Expanded);
-            artistsItem.id = 'search-artists-item';
+            if (responce.playlists) {
+                const playListsItem = new vscode.TreeItem('Плейлисты', vscode.TreeItemCollapsibleState.Expanded);
+                playListsItem.id = 'search-playlists-item';
+                searchItems.push(playListsItem);
+            }
 
-            return [
-                tracksItem,
-                albumsItem,
-                playListsItem,
-                artistsItem
-            ];
+            if (responce.artists) {
+                const artistsItem = new vscode.TreeItem('Исполнители', vscode.TreeItemCollapsibleState.Expanded);
+                artistsItem.id = 'search-artists-item';
+                searchItems.push(artistsItem);
+            }
+
+            return searchItems;
         }
 
         if (element.id === 'search-tracks-item') {
-            // TODO: no need to make request, need to refactor
-            const responce = await this.store.api.search(this.store.searchText);
-            const items = responce.data.result.tracks.results.map(item => new TrackTreeItem(this.store, item, ''));
+            const items = responce.tracks.results.map(item => new TrackTreeItem(this.store, item, SEARCH_TRACKS_PLAYLIST_ID));
             return items;
         }
 
         if (element.id === 'search-albums-item') {
-            // TODO: no need to make request, need to refactor
-            const responce = await this.store.api.search(this.store.searchText);
-            const items = responce.data.result.albums.results.map(item => new AlbumTreeItem(item));
+            const items = responce.albums.results.map(item => new AlbumTreeItem(item));
             return items;
         }
 
         if (element.id === 'search-playlists-item') {
-            // TODO: no need to make request, need to refactor
-            const responce = await this.store.api.search(this.store.searchText);
-            const items = responce.data.result.playlists.results.map(item => new PlayListTreeItem(item));
+            const items = responce.playlists.results.map(item => new PlayListTreeItem(item));
             return items;
         }
 
         if (element.id === 'search-artists-item') {
-            // TODO: no need to make request, need to refactor
-            const responce = await this.store.api.search(this.store.searchText);
-            const items = responce.data.result.artists.results.map(item => new ArtistTreeItem(this.store, item));
+            const items = responce.artists.results.map(item => new ArtistTreeItem(this.store, item));
             return items;
         }
 

--- a/src/tree/searchTree.ts
+++ b/src/tree/searchTree.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { Store } from '../store';
 import { getChildren } from './childrenLoader';
 import { AlbumTreeItem, PlayListTreeItem, TrackTreeItem } from './treeItems';
+import { ArtistTreeItem } from './treeItems/artistTreeItem';
 
 export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
     private _onDidChangeTreeData = new vscode.EventEmitter<vscode.TreeItem | undefined>();
@@ -37,10 +38,14 @@ export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
             const playListsItem = new vscode.TreeItem('Плейлисты', vscode.TreeItemCollapsibleState.Expanded);
             playListsItem.id = 'search-playlists-item';
 
+            const artistsItem = new vscode.TreeItem('Исполнители', vscode.TreeItemCollapsibleState.Expanded);
+            artistsItem.id = 'search-artists-item';
+
             return [
                 tracksItem,
                 albumsItem,
                 playListsItem,
+                artistsItem
             ];
         }
 
@@ -65,7 +70,14 @@ export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
             return items;
         }
 
-        if (element instanceof AlbumTreeItem || element instanceof PlayListTreeItem) {
+        if (element.id === 'search-artists-item') {
+            // TODO: no need to make request, need to refactor
+            const responce = await this.store.api.search(this.store.searchText);
+            const items = responce.data.result.artists.results.map(item => new ArtistTreeItem(this.store, item));
+            return items;
+        }
+
+        if (element instanceof AlbumTreeItem || element instanceof PlayListTreeItem || element instanceof ArtistTreeItem) {
             return getChildren(this.store, element);
         }
 

--- a/src/tree/searchTree.ts
+++ b/src/tree/searchTree.ts
@@ -11,7 +11,7 @@ export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
     constructor(private store: Store) {
-        observe(store, "searchResponse", () => {
+        observe(store, "searchResult", () => {
             this.refresh();
         });
     }
@@ -25,11 +25,11 @@ export class SearchTree implements vscode.TreeDataProvider<vscode.TreeItem> {
     }
 
     async getChildren(element?: vscode.TreeItem) {
-        if (!this.store.searchResponse) {
+        if (!this.store.searchResult) {
             return;
         }
 
-        const responce = this.store.searchResponse;
+        const responce = this.store.searchResult;
 
         if (!element) {
             const searchItems: vscode.TreeItem[] = [];

--- a/src/tree/treeItems/artistTreeItem.ts
+++ b/src/tree/treeItems/artistTreeItem.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode";
 import { Store } from "../../store";
 import { Artist } from "../../yandexApi/interfaces";
-import { TrackTreeItem } from "./trackTreeItem";
 
 export class ArtistTreeItem extends vscode.TreeItem {
     constructor(private store: Store, public readonly artist: Artist) {
@@ -9,14 +8,5 @@ export class ArtistTreeItem extends vscode.TreeItem {
 
         // TODO: add artist icon
         //  this.iconPath = "";
-    }
-
-    getChildren() {
-        if (!this.artist.popularTracks) {
-            return [];
-        }
-
-        // TODO: trackes will not be played as they are not added to the store.playlists
-        return this.artist.popularTracks.map(item => new TrackTreeItem(this.store, item, ''));
     }
 }

--- a/src/tree/treeItems/artistTreeItem.ts
+++ b/src/tree/treeItems/artistTreeItem.ts
@@ -1,12 +1,17 @@
 import * as vscode from "vscode";
 import { Store } from "../../store";
+import { getCoverUri } from "../../yandexApi/apiUtils";
 import { Artist } from "../../yandexApi/interfaces";
 
 export class ArtistTreeItem extends vscode.TreeItem {
     constructor(private store: Store, public readonly artist: Artist) {
         super(artist.name, vscode.TreeItemCollapsibleState.Collapsed);
 
-        // TODO: add artist icon
-        //  this.iconPath = "";
+        if (artist.cover?.uri) {
+            const uri = getCoverUri(artist.cover.uri, 50);
+            this.iconPath = vscode.Uri.parse(uri);
+        } else {
+            this.iconPath = new vscode.ThemeIcon("person");
+        }
     }
 }

--- a/src/tree/treeItems/artistTreeItem.ts
+++ b/src/tree/treeItems/artistTreeItem.ts
@@ -1,0 +1,22 @@
+import * as vscode from "vscode";
+import { Store } from "../../store";
+import { Artist } from "../../yandexApi/interfaces";
+import { TrackTreeItem } from "./trackTreeItem";
+
+export class ArtistTreeItem extends vscode.TreeItem {
+    constructor(private store: Store, public readonly artist: Artist) {
+        super(artist.name, vscode.TreeItemCollapsibleState.Collapsed);
+
+        // TODO: add artist icon
+        //  this.iconPath = "";
+    }
+
+    getChildren() {
+        if (!this.artist.popularTracks) {
+            return [];
+        }
+
+        // TODO: trackes will not be played as they are not added to the store.playlists
+        return this.artist.popularTracks.map(item => new TrackTreeItem(this.store, item, ''));
+    }
+}

--- a/src/tree/treeItems/connectTreeItem.ts
+++ b/src/tree/treeItems/connectTreeItem.ts
@@ -8,7 +8,7 @@ export class ConnectTreeItem extends vscode.TreeItem {
         this.iconPath = getResourceIcon("yandex-music-icon.png");
         this.command = {
             command: "yandexMusic.signIn",
-            title: this.label || '',
+            title: this.label as string ?? '',
             tooltip: this.tooltip,
         };
     }

--- a/src/tree/treeItems/playListTreeItem.ts
+++ b/src/tree/treeItems/playListTreeItem.ts
@@ -8,6 +8,7 @@ export class PlayListTreeItem extends vscode.TreeItem {
 
     this.description = playList.description;
     this.tooltip = `${playList.title}. ${playList.description}`;
+    // TODO load playlist icon
     this.iconPath = getPlayListIcon(playList);
   }
 }

--- a/src/utils/iconUtils.ts
+++ b/src/utils/iconUtils.ts
@@ -4,7 +4,7 @@ import { PlayList } from "../yandexApi/playlist/playList";
 import { GeneratedPlayList } from "../yandexApi/feed/generatedPlayList";
 import { getExtensionPath } from "./extensionUtils";
 
-export function getThemeIcon(iconFileName: string): ThemeIcon {
+export function getThemeIcon(iconFileName: string) {
     return {
         dark: path.join(getExtensionPath(), "resources", "dark", iconFileName),
         light: path.join(getExtensionPath(), "resources", "light", iconFileName),

--- a/src/yandexApi/apiUtils.ts
+++ b/src/yandexApi/apiUtils.ts
@@ -37,7 +37,7 @@ export type CoverSize = 50 | 100 | 150 | 200 | 300 | 400 | 700 | 800 | 1000;
  * @param size cover size
  */
 export function getCoverUri(uriTemplate: string, size: CoverSize) {
-  return `http://${uriTemplate.replace('%%', `${size}x${size}`)}`;
+  return `https://${uriTemplate.replace('%%', `${size}x${size}`)}`;
 }
 
 export function getTrackShortName(name: string) {

--- a/src/yandexApi/interfaces.ts
+++ b/src/yandexApi/interfaces.ts
@@ -48,7 +48,7 @@ export interface TrackItem {
 
 export interface Artist {
   composer: boolean;
-  cover: Cover;
+  cover?: Cover;
   decomposed?: any[];
   genres: any[];
   // TODO: when use "yandexApi.search" id is "number", but when use "yandexApi.getPopularTracks" it is "string" 

--- a/src/yandexApi/interfaces.ts
+++ b/src/yandexApi/interfaces.ts
@@ -195,7 +195,9 @@ export interface ISearchOptions {
   nococrrect?: boolean;
 }
 
-export interface SearchResponse extends YandexMusicResponse<{
+export interface SearchResponse extends YandexMusicResponse<SearchResult> { }
+
+export interface SearchResult {
   misspellCorrected: boolean;
   nocorrect: boolean;
   searchRequestId: string;
@@ -205,17 +207,18 @@ export interface SearchResponse extends YandexMusicResponse<{
    */
   best: any;
   videos: any;
-  tracks: SearchResult<Track>;
-  playlists: SearchResult<PlayList>;
-  albums: SearchResult<Album>;
-  artists: SearchResult<Artist>;
-  podcasts: SearchResult<any>;
-}> { }
+  tracks: SearchTypeResult<Track>;
+  playlists: SearchTypeResult<PlayList>;
+  albums: SearchTypeResult<Album>;
+  artists: SearchTypeResult<Artist>;
+  podcasts: SearchTypeResult<any>;
+}
+
 
 /**
- * Represents search result
+ * Represents search result for tracks, playlists, albums, ...
  */
-export interface SearchResult<T> {
+export interface SearchTypeResult<T> {
   /**
    * Results count
    */

--- a/src/yandexApi/interfaces.ts
+++ b/src/yandexApi/interfaces.ts
@@ -51,7 +51,8 @@ export interface Artist {
   cover: Cover;
   decomposed?: any[];
   genres: any[];
-  id: number;
+  // TODO: when use "yandexApi.search" id is "number", but when use "yandexApi.getPopularTracks" it is "string" 
+  id: string | number;
   name: string;
   various: boolean;
   popularTracks?: Track[];

--- a/src/yandexApi/interfaces.ts
+++ b/src/yandexApi/interfaces.ts
@@ -184,7 +184,7 @@ export const ALL_LANDING_BLOCKS: LandingBlockType[] = [
 ];
 
 export interface ISearchOptions {
-  type?: 'artist' | 'album' | 'track' | 'all';
+  type?: 'artist' | 'album' | 'track' | 'podcast' | 'all';
   page?: number;
   nococrrect?: boolean;
 }
@@ -203,6 +203,7 @@ export interface SearchResponse extends YandexMusicResponse<{
   playlists: SearchResult<PlayList>;
   albums: SearchResult<Album>;
   artists: SearchResult<Artist>;
+  podcasts: SearchResult<any>;
 }> {}
 
 /**

--- a/src/yandexApi/interfaces.ts
+++ b/src/yandexApi/interfaces.ts
@@ -210,7 +210,7 @@ export interface SearchResponse extends YandexMusicResponse<{
   albums: SearchResult<Album>;
   artists: SearchResult<Artist>;
   podcasts: SearchResult<any>;
-}> {}
+}> { }
 
 /**
  * Represents search result
@@ -234,3 +234,7 @@ export interface SearchResult<T> {
   results: T[];
 }
 
+export interface ArtistPopularTracksResponce extends YandexMusicResponse<{
+  artist: Artist;
+  tracks: string[];
+}> { }

--- a/src/yandexApi/interfaces.ts
+++ b/src/yandexApi/interfaces.ts
@@ -1,6 +1,7 @@
 import { LandingBlock } from "./landing/block";
 import { GeneratedPlayListItem } from "./feed/generatedPlayListItem";
 import { Album } from "./album/album";
+import { PlayList } from "./playlist/playList";
 
 export interface GetPlayListsOptions {
   mixed?: boolean;
@@ -181,3 +182,48 @@ export const ALL_LANDING_BLOCKS: LandingBlockType[] = [
   "play_contexts",
   "podcasts",
 ];
+
+export interface ISearchOptions {
+  type?: 'artist' | 'album' | 'track' | 'all';
+  page?: number;
+  nococrrect?: boolean;
+}
+
+export interface SearchResponse extends YandexMusicResponse<{
+  misspellCorrected: boolean;
+  nocorrect: boolean;
+  searchRequestId: string;
+  text: string;
+  /**
+   * The best result
+   */
+  best: any;
+  videos: any;
+  tracks: SearchResult<Track>;
+  playlists: SearchResult<PlayList>;
+  albums: SearchResult<Album>;
+  artists: SearchResult<Artist>;
+}> {}
+
+/**
+ * Represents search result
+ */
+export interface SearchResult<T> {
+  /**
+   * Results count
+   */
+  total: number;
+  /**
+   * Maximum results count on the page
+   */
+  perPage: number;
+  /**
+   * Block position
+   */
+  order: number;
+  /**
+   * Search results
+   */
+  results: T[];
+}
+

--- a/src/yandexApi/interfaces.ts
+++ b/src/yandexApi/interfaces.ts
@@ -54,6 +54,12 @@ export interface Artist {
   id: number;
   name: string;
   various: boolean;
+  popularTracks?: Track[];
+  /**
+   * Имеются ли в продаже билеты на концерт
+   */
+  ticketsAvailable?: boolean;
+  regions?: string[];
 }
 
 export interface Track {

--- a/src/yandexApi/yandexMusicApi.ts
+++ b/src/yandexApi/yandexMusicApi.ts
@@ -11,6 +11,7 @@ import {
   LandingResponse,
   LandingBlockType,
   TrackDownloadInfo,
+  ISearchOptions,
 } from "./interfaces";
 import { createHash } from "crypto";
 import { createTrackAlbumIds, getPlayListsIds } from "./apiUtils";
@@ -265,7 +266,7 @@ export class YandexMusicApi {
                                             nococrrect {Boolean}
      * @returns {Promise}
      */
-  search(query, options) {
+  search(query: string, options: ISearchOptions): Promise<any> {
     const opts = options || {};
 
     return this.apiClient.get(`/search`, {

--- a/src/yandexApi/yandexMusicApi.ts
+++ b/src/yandexApi/yandexMusicApi.ts
@@ -522,6 +522,16 @@ export class YandexMusicApi {
     }
   }
 
+  /**
+   * Returns popular tracks for an artist
+   * @param artistId Artist id
+   */
+  async getPopularTracks(artistId: string): Promise<AxiosResponse<SearchResponse>> {
+    return await this.apiClient.get<SearchResponse>(`/artists/${artistId}/track-ids-by-rating`, {
+      headers: this._getAuthHeader(),
+    });
+  }
+
   async getTrackUrl(id: string): Promise<string> {
     const downloadInfo = await this.getDownloadInfo(id);
     const url = await this.createTrackURL(downloadInfo);

--- a/src/yandexApi/yandexMusicApi.ts
+++ b/src/yandexApi/yandexMusicApi.ts
@@ -13,6 +13,7 @@ import {
   TrackDownloadInfo,
   ISearchOptions,
   SearchResponse,
+  ArtistPopularTracksResponce,
 } from "./interfaces";
 import { createHash } from "crypto";
 import { createTrackAlbumIds, getPlayListsIds } from "./apiUtils";
@@ -526,8 +527,8 @@ export class YandexMusicApi {
    * Returns popular tracks for an artist
    * @param artistId Artist id
    */
-  async getPopularTracks(artistId: string): Promise<AxiosResponse<SearchResponse>> {
-    return await this.apiClient.get<SearchResponse>(`/artists/${artistId}/track-ids-by-rating`, {
+  async getPopularTracks(artistId: string): Promise<AxiosResponse<ArtistPopularTracksResponce>> {
+    return await this.apiClient.get<ArtistPopularTracksResponce>(`/artists/${artistId}/track-ids-by-rating`, {
       headers: this._getAuthHeader(),
     });
   }

--- a/src/yandexApi/yandexMusicApi.ts
+++ b/src/yandexApi/yandexMusicApi.ts
@@ -12,6 +12,7 @@ import {
   LandingBlockType,
   TrackDownloadInfo,
   ISearchOptions,
+  SearchResponse,
 } from "./interfaces";
 import { createHash } from "crypto";
 import { createTrackAlbumIds, getPlayListsIds } from "./apiUtils";
@@ -266,15 +267,15 @@ export class YandexMusicApi {
                                             nococrrect {Boolean}
      * @returns {Promise}
      */
-  search(query: string, options: ISearchOptions): Promise<any> {
+  search(query: string, options?: ISearchOptions): Promise<AxiosResponse<SearchResponse>> {
     const opts = options || {};
 
     return this.apiClient.get(`/search`, {
       params: {
-        type: opts["type"] || "all",
+        type: opts?.type ?? "all",
         text: query,
-        page: opts["page"] || 0,
-        nococrrect: opts["nococrrect"] || false,
+        page: opts.page ?? 0,
+        nococrrect: opts.nococrrect ?? false,
       },
       headers: this._getAuthHeader(),
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,10 +85,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.26.tgz#213e153babac0ed169d44a6d919501e68f59dea9"
   integrity sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==
 
-"@types/vscode@^1.41.0":
-  version "1.41.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.41.0.tgz#b0d75920220f84e07093285e59180c0f11d336cd"
-  integrity sha512-7SfeY5u9jgiELwxyLB3z7l6l/GbN9CqpCQGkcRlB7tKRFBxzbz2PoBfGrLxI1vRfUCIq5+hg5vtDHExwq5j3+A==
+"@types/vscode@^1.53.0":
+  version "1.53.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.53.0.tgz#47b53717af6562f2ad05171bc9c8500824a3905c"
+  integrity sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==
 
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
Functionality requested in the issue following issue #3 

- [x] Button to run search action
- [x] Button to clean search action 
- [x] Add Welcome view when no searches
- [x] Display search results 
- [ ] Show the latest user search queries

![image](https://user-images.githubusercontent.com/9947582/107847803-bb378c80-6dff-11eb-8c25-cd2d9cd3ee88.png)

- [ ] We need to expand search explorer if we perform search and explorer is collapsed?
- [ ] Need to open left panel when run search action but left panel is collapsed
- [ ] Need to clean up search from saved playlists



